### PR TITLE
Change __extend_locales regex to find language for bogus territory

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -365,6 +365,7 @@ tests/03language_pp.t
 tests/03language_xs.t
 tests/03ngettext_pp.t
 tests/03ngettext_xs.t
+tests/03non_regular_region_gettext_dumb.t
 tests/03npgettext_pp.t
 tests/03npgettext_xs.t
 tests/03pgettext_pp.t

--- a/lib/Locale/gettext_pp.pm
+++ b/lib/Locale/gettext_pp.pm
@@ -526,7 +526,7 @@ sub __extend_locales {
 
     foreach my $locale (@locales) {
     	if ($locale =~ /^([a-z][a-z])
-    		(?:(_[A-Z][A-Z])?
+    		(?:(?:(_[A-Z][A-Z])|(?:_[^\@\.\s]*))?
     		 (\.[-_A-Za-z0-9]+)?
     		 )?
     		(\@[-_A-Za-z0-9]+)?$/x) {

--- a/tests/03non_regular_region_gettext_dumb.t
+++ b/tests/03non_regular_region_gettext_dumb.t
@@ -1,0 +1,73 @@
+#! /usr/local/bin/perl -w
+
+# vim: syntax=perl
+# vim: tabstop=4
+
+use strict;
+use utf8;
+
+use Test;
+
+use constant NUM_TESTS => 8;
+
+use Locale::Messages qw (bindtextdomain textdomain gettext nl_putenv);
+use Locale::gettext_pp;
+use POSIX;
+use File::Spec;
+use Encode;
+
+BEGIN {
+    my $selected = Locale::Messages->select_package ('gettext_dumb');
+    if (!$selected || $selected ne 'gettext_dumb') {
+    #my $selected = Locale::Messages->select_package ('gettext_xs');
+    #if (!$selected || $selected ne 'gettext_xs') {
+        print "1..1\nnot ok # Locale::gettext_dumb does not compile: $@!\n";
+	exit 111;
+    }
+    plan tests => NUM_TESTS;
+}
+
+my $locale_dir = $0;
+$locale_dir =~ s,[^\\/]+$,, or $locale_dir = '.';
+$locale_dir .= '/LocaleData';
+
+my $textdomain = 'existing';
+my $bound_dir = bindtextdomain $textdomain => $locale_dir;
+
+ok defined $bound_dir;
+ok (File::Spec->catdir ($bound_dir), File::Spec->catdir ($bound_dir));
+
+my $bound_domain = textdomain $textdomain;
+
+ok defined $bound_domain;
+ok $bound_domain, $textdomain;
+
+nl_putenv "LANGUAGE=xy_something";
+ok gettext "December", "Dezember";
+
+nl_putenv "LANGUAGE=xy_%";
+ok gettext "December", "Dezember";
+
+my $language = 'xy_ÂT';
+my $encoded_language = Encode::encode('UTF-8', $language);
+
+nl_putenv "LANGUAGE=$encoded_language";
+ok gettext "December", "Dezember";
+
+nl_putenv "LANGUAGE=xy_";
+ok gettext "December", "Dezember";
+
+__END__
+
+Local Variables:
+mode: perl
+perl-indent-level: 4
+perl-continued-statement-offset: 4
+perl-continued-brace-offset: 0
+perl-brace-offset: -4
+perl-brace-imaginary-offset: 0
+perl-label-offset: -4
+cperl-indent-level: 4
+cperl-continued-statement-offset: 2
+tab-width: 4
+End:


### PR DESCRIPTION
The POSIX description does not specify any format for territory in https://pubs.opengroup.org/onlinepubs/9799919799/functions/gettext.html. GNU gettext finds the language for such bogus region names.